### PR TITLE
Warning fix on line 116 of fractions.c

### DIFF
--- a/src/fractions.c
+++ b/src/fractions.c
@@ -120,7 +120,7 @@ int fraction_reciprocate(struct fraction *res, const struct fraction *f)
         return -1;
     }
 
-    return fraction_set(res, llcopysign(f->denominator, f->numerator), abs(f->numerator));
+    return fraction_set(res, llcopysign(f->denominator, f->numerator), labs(f->numerator));
 }
 
 int fraction_sum(struct fraction *res, const struct fraction *a, const struct fraction *b)


### PR DESCRIPTION
When compiling a warning is showed about abs() function in fraction_reciprocate() (line 116 fractions.c). The warning reports passing a llint as an int. Using the labs() (takes lint) function shuts down this warning; if using ISOC99 the function llabs() (takes llint) can prevent truncation.